### PR TITLE
Add advanced circuit breaker

### DIFF
--- a/src/ZiggyCreatures.FusionCache/FusionCacheOptions.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCacheOptions.cs
@@ -220,7 +220,11 @@ public class FusionCacheOptions
 	/// <br/><br/>
 	/// <strong>DOCS:</strong> <see href="https://github.com/ZiggyCreatures/FusionCache/blob/main/docs/CacheLevels.md"/>
 	/// </summary>
-	public TimeSpan DistributedCacheCircuitBreakerDuration { get; set; }
+        public TimeSpan DistributedCacheCircuitBreakerDuration { get; set; }
+
+        public bool DistributedCacheUseAdvancedCircuitBreaker { get; set; }
+        public double DistributedCacheCircuitBreakerFailureThreshold { get; set; } = 0.5;
+        public TimeSpan DistributedCacheCircuitBreakerSamplingDuration { get; set; } = TimeSpan.FromSeconds(30);
 
 	/// <summary>
 	/// Execute event handlers in a sync fashion, waiting for all of them to complete before moving on.
@@ -252,7 +256,10 @@ public class FusionCacheOptions
 	/// <br/><br/>
 	/// <strong>DOCS:</strong> <see href="https://github.com/ZiggyCreatures/FusionCache/blob/main/docs/Backplane.md"/>
 	/// </summary>
-	public TimeSpan BackplaneCircuitBreakerDuration { get; set; }
+        public TimeSpan BackplaneCircuitBreakerDuration { get; set; }
+        public bool BackplaneUseAdvancedCircuitBreaker { get; set; }
+        public double BackplaneCircuitBreakerFailureThreshold { get; set; } = 0.5;
+        public TimeSpan BackplaneCircuitBreakerSamplingDuration { get; set; } = TimeSpan.FromSeconds(30);
 
 	/// <summary>
 	/// The prefix to use in the backplane channel name: if not specified the <see cref="CacheName"/> will be used.
@@ -586,13 +593,19 @@ public class FusionCacheOptions
 			AutoRecoveryMaxItems = AutoRecoveryMaxItems,
 			AutoRecoveryMaxRetryCount = AutoRecoveryMaxRetryCount,
 
-			BackplaneChannelPrefix = BackplaneChannelPrefix,
-			IgnoreIncomingBackplaneNotifications = IgnoreIncomingBackplaneNotifications,
-			BackplaneCircuitBreakerDuration = BackplaneCircuitBreakerDuration,
-			WaitForInitialBackplaneSubscribe = WaitForInitialBackplaneSubscribe,
+                        BackplaneChannelPrefix = BackplaneChannelPrefix,
+                        IgnoreIncomingBackplaneNotifications = IgnoreIncomingBackplaneNotifications,
+                        BackplaneCircuitBreakerDuration = BackplaneCircuitBreakerDuration,
+                        BackplaneUseAdvancedCircuitBreaker = BackplaneUseAdvancedCircuitBreaker,
+                        BackplaneCircuitBreakerFailureThreshold = BackplaneCircuitBreakerFailureThreshold,
+                        BackplaneCircuitBreakerSamplingDuration = BackplaneCircuitBreakerSamplingDuration,
+                        WaitForInitialBackplaneSubscribe = WaitForInitialBackplaneSubscribe,
 
-			DistributedCacheKeyModifierMode = DistributedCacheKeyModifierMode,
-			DistributedCacheCircuitBreakerDuration = DistributedCacheCircuitBreakerDuration,
+                        DistributedCacheKeyModifierMode = DistributedCacheKeyModifierMode,
+                        DistributedCacheCircuitBreakerDuration = DistributedCacheCircuitBreakerDuration,
+                        DistributedCacheUseAdvancedCircuitBreaker = DistributedCacheUseAdvancedCircuitBreaker,
+                        DistributedCacheCircuitBreakerFailureThreshold = DistributedCacheCircuitBreakerFailureThreshold,
+                        DistributedCacheCircuitBreakerSamplingDuration = DistributedCacheCircuitBreakerSamplingDuration,
 
 			EnableSyncEventHandlersExecution = EnableSyncEventHandlersExecution,
 

--- a/src/ZiggyCreatures.FusionCache/Internals/AdvancedCircuitBreaker.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/AdvancedCircuitBreaker.cs
@@ -1,0 +1,119 @@
+namespace ZiggyCreatures.Caching.Fusion.Internals;
+
+internal sealed class AdvancedCircuitBreaker : ICircuitBreaker
+{
+    private const int CircuitStateClosed = 0;
+    private const int CircuitStateOpen = 1;
+    private const int CircuitStateHalfOpen = 2;
+
+    private int _circuitState;
+    private long _gatewayTicks;
+    private readonly long _breakDurationTicks;
+    private readonly long _samplingDurationTicks;
+    private readonly double _failureThreshold;
+
+    private int _failureCount;
+    private int _successCount;
+    private long _windowStartTicks;
+
+    public AdvancedCircuitBreaker(double failureThreshold, TimeSpan samplingDuration, TimeSpan breakDuration)
+    {
+        if (failureThreshold <= 0 || failureThreshold > 1)
+            throw new ArgumentOutOfRangeException(nameof(failureThreshold));
+        if (samplingDuration <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(samplingDuration));
+
+        _failureThreshold = failureThreshold;
+        _samplingDurationTicks = samplingDuration.Ticks;
+        BreakDuration = breakDuration;
+        _breakDurationTicks = BreakDuration.Ticks;
+        _gatewayTicks = DateTimeOffset.MinValue.Ticks;
+        _windowStartTicks = DateTimeOffset.UtcNow.Ticks;
+    }
+
+    public TimeSpan BreakDuration { get; private set; }
+
+    private void EnsureWindow()
+    {
+        var now = DateTimeOffset.UtcNow.Ticks;
+        if (now - Interlocked.Read(ref _windowStartTicks) > _samplingDurationTicks)
+        {
+            Interlocked.Exchange(ref _failureCount, 0);
+            Interlocked.Exchange(ref _successCount, 0);
+            Interlocked.Exchange(ref _windowStartTicks, now);
+        }
+    }
+
+    private double FailureRatio()
+    {
+        var failures = Volatile.Read(ref _failureCount);
+        var successes = Volatile.Read(ref _successCount);
+        var total = failures + successes;
+        if (total == 0)
+            return 0;
+        return (double)failures / total;
+    }
+
+    public bool TryOpen(out bool isStateChanged)
+    {
+        if (_breakDurationTicks == 0)
+        {
+            isStateChanged = false;
+            return false;
+        }
+
+        EnsureWindow();
+        Interlocked.Increment(ref _failureCount);
+
+        if (_circuitState == CircuitStateHalfOpen || FailureRatio() >= _failureThreshold)
+        {
+            Interlocked.Exchange(ref _gatewayTicks, DateTimeOffset.UtcNow.Ticks + _breakDurationTicks);
+            var oldState = Interlocked.Exchange(ref _circuitState, CircuitStateOpen);
+            isStateChanged = oldState != CircuitStateOpen;
+            Interlocked.Exchange(ref _failureCount, 0);
+            Interlocked.Exchange(ref _successCount, 0);
+            Interlocked.Exchange(ref _windowStartTicks, DateTimeOffset.UtcNow.Ticks);
+            return true;
+        }
+
+        isStateChanged = false;
+        return _circuitState == CircuitStateOpen;
+    }
+
+    public void Close(out bool isStateChanged)
+    {
+        EnsureWindow();
+        Interlocked.Increment(ref _successCount);
+
+        var oldState = Interlocked.Exchange(ref _circuitState, CircuitStateClosed);
+        isStateChanged = oldState != CircuitStateClosed;
+        if (isStateChanged)
+        {
+            Interlocked.Exchange(ref _gatewayTicks, DateTimeOffset.MinValue.Ticks);
+            Interlocked.Exchange(ref _failureCount, 0);
+            Interlocked.Exchange(ref _successCount, 0);
+            Interlocked.Exchange(ref _windowStartTicks, DateTimeOffset.UtcNow.Ticks);
+        }
+    }
+
+    public bool IsClosed(out bool isStateChanged)
+    {
+        isStateChanged = false;
+
+        if (_breakDurationTicks == 0)
+            return true;
+
+        if (_circuitState == CircuitStateOpen)
+        {
+            var now = DateTimeOffset.UtcNow.Ticks;
+            if (now >= Volatile.Read(ref _gatewayTicks))
+            {
+                Interlocked.Exchange(ref _circuitState, CircuitStateHalfOpen);
+                return true;
+            }
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/ZiggyCreatures.FusionCache/Internals/Backplane/BackplaneAccessor.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/Backplane/BackplaneAccessor.cs
@@ -11,7 +11,7 @@ internal sealed partial class BackplaneAccessor
 	private readonly FusionCacheOptions _options;
 	private readonly ILogger? _logger;
 	private readonly FusionCacheBackplaneEventsHub _events;
-	private readonly SimpleCircuitBreaker _breaker;
+    private readonly ICircuitBreaker _breaker;
 
 	public BackplaneAccessor(FusionCache cache, IFusionCacheBackplane backplane, FusionCacheOptions options, ILogger? logger)
 	{
@@ -29,8 +29,13 @@ internal sealed partial class BackplaneAccessor
 		_logger = logger;
 		_events = _cache.Events.Backplane;
 
-		// CIRCUIT-BREAKER
-		_breaker = new SimpleCircuitBreaker(options.BackplaneCircuitBreakerDuration);
+        // CIRCUIT-BREAKER
+        if (options.BackplaneUseAdvancedCircuitBreaker)
+                _breaker = new AdvancedCircuitBreaker(options.BackplaneCircuitBreakerFailureThreshold,
+                        options.BackplaneCircuitBreakerSamplingDuration,
+                        options.BackplaneCircuitBreakerDuration);
+        else
+                _breaker = new SimpleCircuitBreaker(options.BackplaneCircuitBreakerDuration);
 	}
 
 	public IFusionCacheBackplane Backplane

--- a/src/ZiggyCreatures.FusionCache/Internals/Backplane/BackplaneAccessor_Async.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/Backplane/BackplaneAccessor_Async.cs
@@ -122,7 +122,8 @@ internal partial class BackplaneAccessor
 			if (_logger?.IsEnabled(LogLevel.Trace) ?? false)
 				_logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): [BP] before " + actionDescription, _options.CacheName, _options.InstanceId, operationId, cacheKey);
 
-			await _backplane.PublishAsync(message, options, token).ConfigureAwait(false);
+                        await _backplane.PublishAsync(message, options, token).ConfigureAwait(false);
+                        _breaker.Close(out _);
 
 			// EVENT
 			_events.OnMessagePublished(operationId, message);

--- a/src/ZiggyCreatures.FusionCache/Internals/Backplane/BackplaneAccessor_Sync.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/Backplane/BackplaneAccessor_Sync.cs
@@ -122,7 +122,8 @@ internal partial class BackplaneAccessor
 			if (_logger?.IsEnabled(LogLevel.Trace) ?? false)
 				_logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): [BP] before " + actionDescription, _options.CacheName, _options.InstanceId, operationId, cacheKey);
 
-			_backplane.Publish(message, options, token);
+                        _backplane.Publish(message, options, token);
+                        _breaker.Close(out _);
 
 			// EVENT
 			_events.OnMessagePublished(operationId, message);

--- a/src/ZiggyCreatures.FusionCache/Internals/Distributed/DistributedCacheAccessor.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/Distributed/DistributedCacheAccessor.cs
@@ -13,7 +13,7 @@ internal sealed partial class DistributedCacheAccessor
 	private readonly FusionCacheOptions _options;
 	private readonly ILogger? _logger;
 	private readonly FusionCacheDistributedEventsHub _events;
-	private readonly SimpleCircuitBreaker _breaker;
+    private readonly ICircuitBreaker _breaker;
 	private readonly string _wireFormatToken;
 
 	public DistributedCacheAccessor(IDistributedCache distributedCache, IFusionCacheSerializer serializer, FusionCacheOptions options, ILogger? logger, FusionCacheDistributedEventsHub events)
@@ -32,8 +32,13 @@ internal sealed partial class DistributedCacheAccessor
 		_logger = logger;
 		_events = events;
 
-		// CIRCUIT-BREAKER
-		_breaker = new SimpleCircuitBreaker(options.DistributedCacheCircuitBreakerDuration);
+        // CIRCUIT-BREAKER
+        if (options.DistributedCacheUseAdvancedCircuitBreaker)
+                _breaker = new AdvancedCircuitBreaker(options.DistributedCacheCircuitBreakerFailureThreshold,
+                        options.DistributedCacheCircuitBreakerSamplingDuration,
+                        options.DistributedCacheCircuitBreakerDuration);
+        else
+                _breaker = new SimpleCircuitBreaker(options.DistributedCacheCircuitBreakerDuration);
 
 		// WIRE FORMAT SETUP
 		_wireFormatToken = _options.DistributedCacheKeyModifierMode switch

--- a/src/ZiggyCreatures.FusionCache/Internals/Distributed/DistributedCacheAccessor_Async.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/Distributed/DistributedCacheAccessor_Async.cs
@@ -44,8 +44,9 @@ internal partial class DistributedCacheAccessor
 			return false;
 		}
 
-		return true;
-	}
+                _breaker.Close(out _);
+                return true;
+        }
 
 	public async ValueTask<bool> SetEntryAsync<TValue>(string operationId, string key, IFusionCacheEntry entry, FusionCacheEntryOptions options, bool isBackground, CancellationToken token)
 	{
@@ -155,16 +156,17 @@ internal partial class DistributedCacheAccessor
 
 		// GET FROM DISTRIBUTED CACHE
 		byte[]? data;
-		try
-		{
-			timeout ??= options.GetAppropriateDistributedCacheTimeout(hasFallbackValue);
-			data = await RunUtils.RunAsyncFuncWithTimeoutAsync<byte[]?>(
-				async ct => await _cache.GetAsync(MaybeProcessCacheKey(key), ct).ConfigureAwait(false),
-				timeout.Value,
-				true,
-				token: token
-			).ConfigureAwait(false);
-		}
+                try
+                {
+                        timeout ??= options.GetAppropriateDistributedCacheTimeout(hasFallbackValue);
+                        data = await RunUtils.RunAsyncFuncWithTimeoutAsync<byte[]?>(
+                                async ct => await _cache.GetAsync(MaybeProcessCacheKey(key), ct).ConfigureAwait(false),
+                                timeout.Value,
+                                true,
+                                token: token
+                        ).ConfigureAwait(false);
+                        _breaker.Close(out _);
+                }
 		catch (Exception exc)
 		{
 			ProcessError(operationId, key, exc, "getting entry from distributed");

--- a/src/ZiggyCreatures.FusionCache/Internals/Distributed/DistributedCacheAccessor_Sync.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/Distributed/DistributedCacheAccessor_Sync.cs
@@ -44,8 +44,9 @@ internal partial class DistributedCacheAccessor
 			return false;
 		}
 
-		return true;
-	}
+                _breaker.Close(out _);
+                return true;
+        }
 
 	public bool SetEntry<TValue>(string operationId, string key, IFusionCacheEntry entry, FusionCacheEntryOptions options, bool isBackground, CancellationToken token)
 	{
@@ -151,13 +152,14 @@ internal partial class DistributedCacheAccessor
 		try
 		{
 			timeout ??= options.GetAppropriateDistributedCacheTimeout(hasFallbackValue);
-			data = RunUtils.RunSyncFuncWithTimeout<byte[]?>(
-				_ => _cache.Get(MaybeProcessCacheKey(key)),
-				timeout.Value,
-				true,
-				token: token
-			);
-		}
+                        data = RunUtils.RunSyncFuncWithTimeout<byte[]?>(
+                                _ => _cache.Get(MaybeProcessCacheKey(key)),
+                                timeout.Value,
+                                true,
+                                token: token
+                        );
+                        _breaker.Close(out _);
+                }
 		catch (Exception exc)
 		{
 			ProcessError(operationId, key, exc, "getting entry from distributed");

--- a/src/ZiggyCreatures.FusionCache/Internals/ICircuitBreaker.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/ICircuitBreaker.cs
@@ -1,0 +1,9 @@
+namespace ZiggyCreatures.Caching.Fusion.Internals;
+
+internal interface ICircuitBreaker
+{
+    TimeSpan BreakDuration { get; }
+    bool TryOpen(out bool isStateChanged);
+    void Close(out bool isStateChanged);
+    bool IsClosed(out bool isStateChanged);
+}

--- a/src/ZiggyCreatures.FusionCache/Internals/SimpleCircuitBreaker.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/SimpleCircuitBreaker.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// A simple, reusable circuit-breaker.
 /// </summary>
-internal sealed class SimpleCircuitBreaker
+internal sealed class SimpleCircuitBreaker : ICircuitBreaker
 {
 	private const int CircuitStateClosed = 0;
 	private const int CircuitStateOpen = 1;

--- a/tests/ZiggyCreatures.FusionCache.Tests/L1L2Tests_Async.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/L1L2Tests_Async.cs
@@ -113,7 +113,7 @@ public partial class L1L2Tests
 
 	[Theory]
 	[ClassData(typeof(SerializerTypesClassData))]
-	public async Task DistributedCacheCircuitBreakerActuallyWorksAsync(SerializerType serializerType)
+        public async Task DistributedCacheCircuitBreakerActuallyWorksAsync(SerializerType serializerType)
 	{
 		var keyFoo = CreateRandomCacheKey("foo");
 
@@ -138,8 +138,42 @@ public partial class L1L2Tests
 		memoryCache.Remove(TestsUtils.MaybePreProcessCacheKey(keyFoo, TestingCacheKeyPrefix));
 		var res = await fusionCache.GetOrDefaultAsync<int>(keyFoo, -1, token: TestContext.Current.CancellationToken);
 
-		Assert.Equal(1, res);
-	}
+                Assert.Equal(1, res);
+        }
+
+        [Theory]
+        [ClassData(typeof(SerializerTypesClassData))]
+        public async Task DistributedCacheAdvancedCircuitBreakerWorksAsync(SerializerType serializerType)
+        {
+                var keyFoo = CreateRandomCacheKey("foo");
+
+                var circuitBreakerDuration = TimeSpan.FromSeconds(1);
+                var distributedCache = CreateDistributedCache();
+                var chaosDistributedCache = new ChaosDistributedCache(distributedCache);
+
+                using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+                var options = CreateFusionCacheOptions();
+                options.EnableAutoRecovery = false;
+                options.DistributedCacheUseAdvancedCircuitBreaker = true;
+                options.DistributedCacheCircuitBreakerFailureThreshold = 0.5;
+                options.DistributedCacheCircuitBreakerSamplingDuration = TimeSpan.FromMilliseconds(200);
+                options.DistributedCacheCircuitBreakerDuration = circuitBreakerDuration;
+                using var fusionCache = new FusionCache(options, memoryCache);
+                fusionCache.DefaultEntryOptions.AllowBackgroundDistributedCacheOperations = false;
+                fusionCache.SetupDistributedCache(chaosDistributedCache, TestsUtils.GetSerializer(serializerType));
+
+                await fusionCache.SetAsync<int>(keyFoo, 1, options => options.SetDurationSec(60).SetFailSafe(true), token: TestContext.Current.CancellationToken);
+                chaosDistributedCache.SetAlwaysThrow();
+                await fusionCache.SetAsync<int>(keyFoo, 2, options => options.SetDurationSec(60).SetFailSafe(true), token: TestContext.Current.CancellationToken);
+                await fusionCache.SetAsync<int>(keyFoo, 3, options => options.SetDurationSec(60).SetFailSafe(true), token: TestContext.Current.CancellationToken);
+                chaosDistributedCache.SetNeverThrow();
+                await fusionCache.SetAsync<int>(keyFoo, 4, options => options.SetDurationSec(60).SetFailSafe(true), token: TestContext.Current.CancellationToken);
+                await Task.Delay(circuitBreakerDuration.PlusALittleBit(), TestContext.Current.CancellationToken);
+                memoryCache.Remove(TestsUtils.MaybePreProcessCacheKey(keyFoo, TestingCacheKeyPrefix));
+                var res = await fusionCache.GetOrDefaultAsync<int>(keyFoo, -1, token: TestContext.Current.CancellationToken);
+
+                Assert.Equal(1, res);
+        }
 
 	private async Task _DistributedCacheWireVersionModifierWorksAsync(SerializerType serializerType, CacheKeyModifierMode modifierMode)
 	{

--- a/tests/ZiggyCreatures.FusionCache.Tests/L1L2Tests_Sync.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/L1L2Tests_Sync.cs
@@ -112,7 +112,7 @@ public partial class L1L2Tests
 
 	[Theory]
 	[ClassData(typeof(SerializerTypesClassData))]
-	public void DistributedCacheCircuitBreakerActuallyWorks(SerializerType serializerType)
+        public void DistributedCacheCircuitBreakerActuallyWorks(SerializerType serializerType)
 	{
 		var keyFoo = CreateRandomCacheKey("foo");
 
@@ -137,8 +137,42 @@ public partial class L1L2Tests
 		memoryCache.Remove(TestsUtils.MaybePreProcessCacheKey(keyFoo, TestingCacheKeyPrefix));
 		var res = fusionCache.GetOrDefault<int>(keyFoo, -1, token: TestContext.Current.CancellationToken);
 
-		Assert.Equal(1, res);
-	}
+                Assert.Equal(1, res);
+        }
+
+        [Theory]
+        [ClassData(typeof(SerializerTypesClassData))]
+        public void DistributedCacheAdvancedCircuitBreakerWorks(SerializerType serializerType)
+        {
+                var keyFoo = CreateRandomCacheKey("foo");
+
+                var circuitBreakerDuration = TimeSpan.FromSeconds(1);
+                var distributedCache = CreateDistributedCache();
+                var chaosDistributedCache = new ChaosDistributedCache(distributedCache);
+
+                using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+                var options = CreateFusionCacheOptions();
+                options.EnableAutoRecovery = false;
+                options.DistributedCacheUseAdvancedCircuitBreaker = true;
+                options.DistributedCacheCircuitBreakerFailureThreshold = 0.5;
+                options.DistributedCacheCircuitBreakerSamplingDuration = TimeSpan.FromMilliseconds(200);
+                options.DistributedCacheCircuitBreakerDuration = circuitBreakerDuration;
+                using var fusionCache = new FusionCache(options, memoryCache);
+                fusionCache.DefaultEntryOptions.AllowBackgroundDistributedCacheOperations = false;
+                fusionCache.SetupDistributedCache(chaosDistributedCache, TestsUtils.GetSerializer(serializerType));
+
+                fusionCache.Set<int>(keyFoo, 1, options => options.SetDurationSec(60).SetFailSafe(true), token: TestContext.Current.CancellationToken);
+                chaosDistributedCache.SetAlwaysThrow();
+                fusionCache.Set<int>(keyFoo, 2, options => options.SetDurationSec(60).SetFailSafe(true), token: TestContext.Current.CancellationToken);
+                fusionCache.Set<int>(keyFoo, 3, options => options.SetDurationSec(60).SetFailSafe(true), token: TestContext.Current.CancellationToken);
+                chaosDistributedCache.SetNeverThrow();
+                fusionCache.Set<int>(keyFoo, 4, options => options.SetDurationSec(60).SetFailSafe(true), token: TestContext.Current.CancellationToken);
+                Thread.Sleep(circuitBreakerDuration.PlusALittleBit());
+                memoryCache.Remove(TestsUtils.MaybePreProcessCacheKey(keyFoo, TestingCacheKeyPrefix));
+                var res = fusionCache.GetOrDefault<int>(keyFoo, -1, token: TestContext.Current.CancellationToken);
+
+                Assert.Equal(1, res);
+        }
 
 	private void _DistributedCacheWireVersionModifierWorks(SerializerType serializerType, CacheKeyModifierMode modifierMode)
 	{


### PR DESCRIPTION
## Summary
- introduce `ICircuitBreaker` interface and `AdvancedCircuitBreaker`
- support advanced breaker in distributed cache and backplane accessors
- expose configuration options for advanced breaker
- update simple breaker to implement the interface
- test advanced circuit breaker behaviour

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68869c19cf1883338c80429c6a823243