### PR TITLE
Implement advanced circuit breaker

### DIFF
--- a/src/ZiggyCreatures.FusionCache/FusionCacheOptions.cs
+++ b/src/ZiggyCreatures.FusionCache/FusionCacheOptions.cs
@@ -187,12 +187,27 @@ public class FusionCacheOptions
 		}
 	}
 
-	/// <summary>
-	/// The duration of the circuit-breaker used when working with the distributed cache. Defaults to <see cref="TimeSpan.Zero"/>, which means the circuit-breaker will never be activated.
-	/// <br/><br/>
-	/// <strong>DOCS:</strong> <see href="https://github.com/ZiggyCreatures/FusionCache/blob/main/docs/CacheLevels.md"/>
-	/// </summary>
-	public TimeSpan DistributedCacheCircuitBreakerDuration { get; set; }
+        /// <summary>
+        /// The duration of the circuit-breaker used when working with the distributed cache. Defaults to <see cref="TimeSpan.Zero"/>, which means the circuit-breaker will never be activated.
+        /// <br/><br/>
+        /// <strong>DOCS:</strong> <see href="https://github.com/ZiggyCreatures/FusionCache/blob/main/docs/CacheLevels.md"/>
+        /// </summary>
+        public TimeSpan DistributedCacheCircuitBreakerDuration { get; set; }
+
+        /// <summary>
+        /// When using an advanced circuit-breaker this represents the failure threshold (between 0 and 1) above which the circuit will open.
+        /// </summary>
+        public double DistributedCacheCircuitBreakerFailureThreshold { get; set; }
+
+        /// <summary>
+        /// The sampling duration for the advanced circuit-breaker.
+        /// </summary>
+        public TimeSpan DistributedCacheCircuitBreakerSamplingDuration { get; set; }
+
+        /// <summary>
+        /// The minimum throughput required before the advanced circuit-breaker can trip.
+        /// </summary>
+        public int DistributedCacheCircuitBreakerMinimumThroughput { get; set; }
 
 	/// <summary>
 	/// Execute event handlers in a sync fashion, waiting for all of them to complete before moving on.
@@ -224,7 +239,22 @@ public class FusionCacheOptions
 	/// <br/><br/>
 	/// <strong>DOCS:</strong> <see href="https://github.com/ZiggyCreatures/FusionCache/blob/main/docs/Backplane.md"/>
 	/// </summary>
-	public TimeSpan BackplaneCircuitBreakerDuration { get; set; }
+        public TimeSpan BackplaneCircuitBreakerDuration { get; set; }
+
+        /// <summary>
+        /// When using an advanced circuit-breaker this represents the failure threshold (between 0 and 1) above which the circuit will open.
+        /// </summary>
+        public double BackplaneCircuitBreakerFailureThreshold { get; set; }
+
+        /// <summary>
+        /// The sampling duration for the advanced circuit-breaker.
+        /// </summary>
+        public TimeSpan BackplaneCircuitBreakerSamplingDuration { get; set; }
+
+        /// <summary>
+        /// The minimum throughput required before the advanced circuit-breaker can trip.
+        /// </summary>
+        public int BackplaneCircuitBreakerMinimumThroughput { get; set; }
 
 	/// <summary>
 	/// The prefix to use in the backplane channel name: if not specified the <see cref="CacheName"/> will be used.
@@ -557,11 +587,17 @@ public class FusionCacheOptions
 
 			BackplaneChannelPrefix = BackplaneChannelPrefix,
 			IgnoreIncomingBackplaneNotifications = IgnoreIncomingBackplaneNotifications,
-			BackplaneCircuitBreakerDuration = BackplaneCircuitBreakerDuration,
-			WaitForInitialBackplaneSubscribe = WaitForInitialBackplaneSubscribe,
+                        BackplaneCircuitBreakerDuration = BackplaneCircuitBreakerDuration,
+                        BackplaneCircuitBreakerFailureThreshold = BackplaneCircuitBreakerFailureThreshold,
+                        BackplaneCircuitBreakerSamplingDuration = BackplaneCircuitBreakerSamplingDuration,
+                        BackplaneCircuitBreakerMinimumThroughput = BackplaneCircuitBreakerMinimumThroughput,
+                        WaitForInitialBackplaneSubscribe = WaitForInitialBackplaneSubscribe,
 
-			DistributedCacheKeyModifierMode = DistributedCacheKeyModifierMode,
-			DistributedCacheCircuitBreakerDuration = DistributedCacheCircuitBreakerDuration,
+                        DistributedCacheKeyModifierMode = DistributedCacheKeyModifierMode,
+                        DistributedCacheCircuitBreakerDuration = DistributedCacheCircuitBreakerDuration,
+                        DistributedCacheCircuitBreakerFailureThreshold = DistributedCacheCircuitBreakerFailureThreshold,
+                        DistributedCacheCircuitBreakerSamplingDuration = DistributedCacheCircuitBreakerSamplingDuration,
+                        DistributedCacheCircuitBreakerMinimumThroughput = DistributedCacheCircuitBreakerMinimumThroughput,
 
 			EnableSyncEventHandlersExecution = EnableSyncEventHandlersExecution,
 

--- a/src/ZiggyCreatures.FusionCache/Internals/Backplane/BackplaneAccessor.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/Backplane/BackplaneAccessor.cs
@@ -30,7 +30,12 @@ internal sealed partial class BackplaneAccessor
 		_events = _cache.Events.Backplane;
 
 		// CIRCUIT-BREAKER
-		_breaker = new SimpleCircuitBreaker(options.BackplaneCircuitBreakerDuration);
+                _breaker = new SimpleCircuitBreaker(
+                        options.BackplaneCircuitBreakerDuration,
+                        options.BackplaneCircuitBreakerFailureThreshold,
+                        options.BackplaneCircuitBreakerSamplingDuration,
+                        options.BackplaneCircuitBreakerMinimumThroughput
+                );
 	}
 
 	public IFusionCacheBackplane Backplane

--- a/src/ZiggyCreatures.FusionCache/Internals/Backplane/BackplaneAccessor_Async.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/Backplane/BackplaneAccessor_Async.cs
@@ -111,16 +111,25 @@ internal partial class BackplaneAccessor
 			if (_logger?.IsEnabled(LogLevel.Trace) ?? false)
 				_logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): [BP] before " + actionDescription, _options.CacheName, _options.InstanceId, operationId, cacheKey);
 
-			await _backplane.PublishAsync(message, options, token).ConfigureAwait(false);
+                        await _backplane.PublishAsync(message, options, token).ConfigureAwait(false);
 
-			// EVENT
-			_events.OnMessagePublished(operationId, message);
+                        // EVENT
+                        _events.OnMessagePublished(operationId, message);
 
-			if (_logger?.IsEnabled(LogLevel.Trace) ?? false)
-				_logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): [BP] after " + actionDescription, _options.CacheName, _options.InstanceId, operationId, cacheKey);
-		}
-		catch (Exception exc)
-		{
+                        if (_logger?.IsEnabled(LogLevel.Trace) ?? false)
+                                _logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): [BP] after " + actionDescription, _options.CacheName, _options.InstanceId, operationId, cacheKey);
+
+                        _breaker.OnSuccess(out var changed);
+                        if (changed)
+                        {
+                                if (_logger?.IsEnabled(LogLevel.Warning) ?? false)
+                                        _logger.Log(LogLevel.Warning, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): [BP] backplane activated again", _options.CacheName, _options.InstanceId, operationId, cacheKey);
+
+                                _events.OnCircuitBreakerChange(operationId, cacheKey, true);
+                        }
+                }
+                catch (Exception exc)
+                {
 			ProcessError(operationId, cacheKey, exc, actionDescription);
 
 			// ACTIVITY

--- a/src/ZiggyCreatures.FusionCache/Internals/Backplane/BackplaneAccessor_Sync.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/Backplane/BackplaneAccessor_Sync.cs
@@ -111,16 +111,25 @@ internal partial class BackplaneAccessor
 			if (_logger?.IsEnabled(LogLevel.Trace) ?? false)
 				_logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): [BP] before " + actionDescription, _options.CacheName, _options.InstanceId, operationId, cacheKey);
 
-			_backplane.Publish(message, options, token);
+                        _backplane.Publish(message, options, token);
 
-			// EVENT
-			_events.OnMessagePublished(operationId, message);
+                        // EVENT
+                        _events.OnMessagePublished(operationId, message);
 
-			if (_logger?.IsEnabled(LogLevel.Trace) ?? false)
-				_logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): [BP] after " + actionDescription, _options.CacheName, _options.InstanceId, operationId, cacheKey);
-		}
-		catch (Exception exc)
-		{
+                        if (_logger?.IsEnabled(LogLevel.Trace) ?? false)
+                                _logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): [BP] after " + actionDescription, _options.CacheName, _options.InstanceId, operationId, cacheKey);
+
+                        _breaker.OnSuccess(out var changed);
+                        if (changed)
+                        {
+                                if (_logger?.IsEnabled(LogLevel.Warning) ?? false)
+                                        _logger.Log(LogLevel.Warning, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): [BP] backplane activated again", _options.CacheName, _options.InstanceId, operationId, cacheKey);
+
+                                _events.OnCircuitBreakerChange(operationId, cacheKey, true);
+                        }
+                }
+                catch (Exception exc)
+                {
 			ProcessError(operationId, cacheKey, exc, actionDescription);
 
 			// ACTIVITY

--- a/src/ZiggyCreatures.FusionCache/Internals/Distributed/DistributedCacheAccessor.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/Distributed/DistributedCacheAccessor.cs
@@ -33,7 +33,12 @@ internal sealed partial class DistributedCacheAccessor
 		_events = events;
 
 		// CIRCUIT-BREAKER
-		_breaker = new SimpleCircuitBreaker(options.DistributedCacheCircuitBreakerDuration);
+                _breaker = new SimpleCircuitBreaker(
+                        options.DistributedCacheCircuitBreakerDuration,
+                        options.DistributedCacheCircuitBreakerFailureThreshold,
+                        options.DistributedCacheCircuitBreakerSamplingDuration,
+                        options.DistributedCacheCircuitBreakerMinimumThroughput
+                );
 
 		// WIRE FORMAT SETUP
 		_wireFormatToken = _options.DistributedCacheKeyModifierMode == CacheKeyModifierMode.Prefix

--- a/src/ZiggyCreatures.FusionCache/Internals/Distributed/DistributedCacheAccessor_Async.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/Distributed/DistributedCacheAccessor_Async.cs
@@ -16,13 +16,22 @@ internal partial class DistributedCacheAccessor
 			if (_logger?.IsEnabled(LogLevel.Trace) ?? false)
 				_logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): [DC] before " + actionDescription, _options.CacheName, _options.InstanceId, operationId, key);
 
-			await RunUtils.RunAsyncActionWithTimeoutAsync(action, Timeout.InfiniteTimeSpan, true, token: token).ConfigureAwait(false);
+                        await RunUtils.RunAsyncActionWithTimeoutAsync(action, Timeout.InfiniteTimeSpan, true, token: token).ConfigureAwait(false);
 
-			if (_logger?.IsEnabled(LogLevel.Trace) ?? false)
-				_logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): [DC] after " + actionDescription, _options.CacheName, _options.InstanceId, operationId, key);
-		}
-		catch (Exception exc)
-		{
+                        if (_logger?.IsEnabled(LogLevel.Trace) ?? false)
+                                _logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): [DC] after " + actionDescription, _options.CacheName, _options.InstanceId, operationId, key);
+
+                        _breaker.OnSuccess(out var breakerChanged);
+                        if (breakerChanged)
+                        {
+                                if (_logger?.IsEnabled(LogLevel.Warning) ?? false)
+                                        _logger.Log(LogLevel.Warning, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): [DC] distributed cache activated again", _options.CacheName, _options.InstanceId, operationId, key);
+
+                                _events.OnCircuitBreakerChange(operationId, key, true);
+                        }
+                }
+                catch (Exception exc)
+                {
 			ProcessError(operationId, key, exc, actionDescription);
 
 			// ACTIVITY

--- a/src/ZiggyCreatures.FusionCache/Internals/Distributed/DistributedCacheAccessor_Sync.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/Distributed/DistributedCacheAccessor_Sync.cs
@@ -16,13 +16,22 @@ internal partial class DistributedCacheAccessor
 			if (_logger?.IsEnabled(LogLevel.Trace) ?? false)
 				_logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): [DC] before " + actionDescription, _options.CacheName, _options.InstanceId, operationId, key);
 
-			RunUtils.RunSyncActionWithTimeout(action, Timeout.InfiniteTimeSpan, true, token: token);
+                        RunUtils.RunSyncActionWithTimeout(action, Timeout.InfiniteTimeSpan, true, token: token);
 
-			if (_logger?.IsEnabled(LogLevel.Trace) ?? false)
-				_logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): [DC] after " + actionDescription, _options.CacheName, _options.InstanceId, operationId, key);
-		}
-		catch (Exception exc)
-		{
+                        if (_logger?.IsEnabled(LogLevel.Trace) ?? false)
+                                _logger.Log(LogLevel.Trace, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): [DC] after " + actionDescription, _options.CacheName, _options.InstanceId, operationId, key);
+
+                        _breaker.OnSuccess(out var breakerChanged);
+                        if (breakerChanged)
+                        {
+                                if (_logger?.IsEnabled(LogLevel.Warning) ?? false)
+                                        _logger.Log(LogLevel.Warning, "FUSION [N={CacheName} I={CacheInstanceId}] (O={CacheOperationId} K={CacheKey}): [DC] distributed cache activated again", _options.CacheName, _options.InstanceId, operationId, key);
+
+                                _events.OnCircuitBreakerChange(operationId, key, true);
+                        }
+                }
+                catch (Exception exc)
+                {
 			ProcessError(operationId, key, exc, actionDescription);
 
 			// ACTIVITY

--- a/src/ZiggyCreatures.FusionCache/Internals/SimpleCircuitBreaker.cs
+++ b/src/ZiggyCreatures.FusionCache/Internals/SimpleCircuitBreaker.cs
@@ -5,23 +5,40 @@
 /// </summary>
 internal sealed class SimpleCircuitBreaker
 {
-	private const int CircuitStateClosed = 0;
-	private const int CircuitStateOpen = 1;
+        private const int CircuitStateClosed = 0;
+        private const int CircuitStateOpen = 1;
+        private const int CircuitStateHalfOpen = 2;
 
-	private int _circuitState;
-	private long _gatewayTicks;
-	private readonly long _breakDurationTicks;
+        private int _circuitState;
+        private long _gatewayTicks;
+        private readonly long _breakDurationTicks;
+
+        private readonly double _failureThreshold;
+        private readonly long _samplingDurationTicks;
+        private readonly int _minimumThroughput;
+        private long _windowStartTicks;
+        private int _failureCount;
+        private int _successCount;
+        private int _halfOpenInUse;
 
 	/// <summary>
 	/// Creates a new <see cref="SimpleCircuitBreaker"/> instance.
 	/// </summary>
-	/// <param name="breakDuration">The amount of time the circuit will remain open, when told to.</param>
-	public SimpleCircuitBreaker(TimeSpan breakDuration)
-	{
-		BreakDuration = breakDuration;
-		_breakDurationTicks = BreakDuration.Ticks;
-		_gatewayTicks = DateTimeOffset.MinValue.Ticks;
-	}
+        /// <param name="breakDuration">The amount of time the circuit will remain open, when told to.</param>
+        /// <param name="failureThreshold">The failure threshold for the advanced mode.</param>
+        /// <param name="samplingDuration">The sampling duration for the advanced mode.</param>
+        /// <param name="minimumThroughput">The minimum throughput for the advanced mode.</param>
+        public SimpleCircuitBreaker(TimeSpan breakDuration, double failureThreshold = 0d, TimeSpan? samplingDuration = null, int minimumThroughput = 0)
+        {
+                BreakDuration = breakDuration;
+                _breakDurationTicks = BreakDuration.Ticks;
+                _gatewayTicks = DateTimeOffset.MinValue.Ticks;
+
+                _failureThreshold = failureThreshold;
+                _samplingDurationTicks = samplingDuration?.Ticks ?? 0;
+                _minimumThroughput = minimumThroughput;
+                _windowStartTicks = DateTimeOffset.UtcNow.Ticks;
+        }
 
 	/// <summary>
 	/// The amount of time the circuit will remain open, when told to.
@@ -33,16 +50,50 @@ internal sealed class SimpleCircuitBreaker
 	/// </summary>
 	/// <param name="isStateChanged">Indicates if the circuit has been opened with this operation.</param>
 	/// <returns><see langword="true"/> if the circuit is open, either because it was already or because it has been opened with this operation. <see langword="false"/> otherwise.</returns>
-	public bool TryOpen(out bool isStateChanged)
-	{
-		// NO CIRCUIT-BREAKER DURATION
-		if (_breakDurationTicks == 0)
-		{
-			isStateChanged = false;
-			return false;
-		}
+        public bool TryOpen(out bool isStateChanged)
+        {
+                // NO CIRCUIT-BREAKER DURATION
+                if (_breakDurationTicks == 0)
+                {
+                        isStateChanged = false;
+                        return false;
+                }
 
-		Interlocked.Exchange(ref _gatewayTicks, DateTimeOffset.UtcNow.Ticks + _breakDurationTicks);
+                if (_samplingDurationTicks > 0 && _minimumThroughput > 0 && _failureThreshold > 0)
+                {
+                        var now = DateTimeOffset.UtcNow.Ticks;
+                        UpdateWindow(now);
+                        Interlocked.Increment(ref _failureCount);
+
+                        // HALF-OPEN -> FAILURE
+                        if (_circuitState == CircuitStateHalfOpen)
+                        {
+                                Interlocked.Exchange(ref _gatewayTicks, now + _breakDurationTicks);
+                                var oldState = Interlocked.Exchange(ref _circuitState, CircuitStateOpen);
+                                Interlocked.Exchange(ref _halfOpenInUse, 0);
+                                ResetCounts(now);
+                                isStateChanged = oldState != CircuitStateOpen;
+                                return true;
+                        }
+
+                        var failures = Volatile.Read(ref _failureCount);
+                        var successes = Volatile.Read(ref _successCount);
+                        var total = failures + successes;
+
+                        if (total >= _minimumThroughput && (double)failures / total >= _failureThreshold)
+                        {
+                                Interlocked.Exchange(ref _gatewayTicks, now + _breakDurationTicks);
+                                var oldState = Interlocked.Exchange(ref _circuitState, CircuitStateOpen);
+                                ResetCounts(now);
+                                isStateChanged = oldState != CircuitStateOpen;
+                                return true;
+                        }
+
+                        isStateChanged = false;
+                        return _circuitState == CircuitStateOpen;
+                }
+
+                Interlocked.Exchange(ref _gatewayTicks, DateTimeOffset.UtcNow.Ticks + _breakDurationTicks);
 
 		// DETECT CIRCUIT STATE CHANGE
 		var oldCircuitState = Interlocked.Exchange(ref _circuitState, CircuitStateOpen);
@@ -55,41 +106,97 @@ internal sealed class SimpleCircuitBreaker
 	/// Close the circuit.
 	/// </summary>
 	/// <param name="isStateChanged">Indicates if the circuit has been closed with this operation.</param>
-	public void Close(out bool isStateChanged)
-	{
-		Interlocked.Exchange(ref _gatewayTicks, DateTimeOffset.MinValue.Ticks);
+        public void Close(out bool isStateChanged)
+        {
+                Interlocked.Exchange(ref _gatewayTicks, DateTimeOffset.MinValue.Ticks);
 
-		// DETECT CIRCUIT STATE CHANGE
-		var oldCircuitState = Interlocked.Exchange(ref _circuitState, CircuitStateClosed);
-
-		isStateChanged = oldCircuitState == CircuitStateOpen;
-	}
+                // DETECT CIRCUIT STATE CHANGE
+                var oldCircuitState = Interlocked.Exchange(ref _circuitState, CircuitStateClosed);
+                ResetCounts(DateTimeOffset.UtcNow.Ticks);
+                
+                isStateChanged = oldCircuitState == CircuitStateOpen;
+        }
 
 	/// <summary>
 	/// Check if the circuit is closed, or has been closed with this operation.
 	/// </summary>
 	/// <param name="isStateChanged">Indicates if the circuit has been closed with this operation.</param>
 	/// <returns><see langword="true"/> if the circuit is closed, either because it was already closed or because it has been closed with this operation. <see langword="false"/> otherwise.</returns>
-	public bool IsClosed(out bool isStateChanged)
-	{
-		isStateChanged = false;
+        public bool IsClosed(out bool isStateChanged)
+        {
+                isStateChanged = false;
 
-		// NO CIRCUIT-BREAKER DURATION
-		if (_breakDurationTicks == 0)
-			return true;
+                // NO CIRCUIT-BREAKER DURATION
+                if (_breakDurationTicks == 0)
+                        return true;
 
-		long gatewayTicksLocal = Interlocked.Read(ref _gatewayTicks);
+                var now = DateTimeOffset.UtcNow.Ticks;
+                long gatewayTicksLocal = Interlocked.Read(ref _gatewayTicks);
 
-		// NOT ENOUGH TIME IS PASSED
-		if (DateTimeOffset.UtcNow.Ticks < gatewayTicksLocal)
-			return false;
+                if (now < gatewayTicksLocal)
+                        return false;
 
-		if (_circuitState == CircuitStateOpen)
-		{
-			var oldCircuitState = Interlocked.Exchange(ref _circuitState, CircuitStateClosed);
-			isStateChanged = oldCircuitState == CircuitStateOpen;
-		}
+                if (_circuitState == CircuitStateOpen)
+                {
+                        if (_samplingDurationTicks > 0 && _minimumThroughput > 0 && _failureThreshold > 0)
+                        {
+                                var old = Interlocked.Exchange(ref _circuitState, CircuitStateHalfOpen);
+                                isStateChanged = old != CircuitStateHalfOpen;
+                                return Interlocked.CompareExchange(ref _halfOpenInUse, 1, 0) == 0;
+                        }
 
-		return true;
-	}
+                        var oldCircuitState = Interlocked.Exchange(ref _circuitState, CircuitStateClosed);
+                        isStateChanged = oldCircuitState == CircuitStateOpen;
+                        return true;
+                }
+
+                if (_circuitState == CircuitStateHalfOpen)
+                {
+                        return Interlocked.CompareExchange(ref _halfOpenInUse, 1, 0) == 0;
+                }
+
+                if (_samplingDurationTicks > 0 && _minimumThroughput > 0 && _failureThreshold > 0)
+                        UpdateWindow(now);
+
+                return true;
+        }
+
+        public void OnSuccess(out bool isStateChanged)
+        {
+                isStateChanged = false;
+
+                if (_samplingDurationTicks > 0 && _minimumThroughput > 0 && _failureThreshold > 0)
+                {
+                        var now = DateTimeOffset.UtcNow.Ticks;
+                        UpdateWindow(now);
+                        Interlocked.Increment(ref _successCount);
+
+                        if (_circuitState == CircuitStateHalfOpen)
+                        {
+                                var old = Interlocked.Exchange(ref _circuitState, CircuitStateClosed);
+                                Interlocked.Exchange(ref _halfOpenInUse, 0);
+                                ResetCounts(now);
+                                isStateChanged = old != CircuitStateClosed;
+                        }
+                }
+        }
+
+        private void UpdateWindow(long now)
+        {
+                if (_samplingDurationTicks <= 0)
+                        return;
+
+                var start = Volatile.Read(ref _windowStartTicks);
+                if (now - start > _samplingDurationTicks)
+                {
+                        ResetCounts(now);
+                }
+        }
+
+        private void ResetCounts(long now)
+        {
+                Interlocked.Exchange(ref _windowStartTicks, now);
+                Interlocked.Exchange(ref _failureCount, 0);
+                Interlocked.Exchange(ref _successCount, 0);
+        }
 }

--- a/tests/ZiggyCreatures.FusionCache.Tests/L1L2Tests_Async.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/L1L2Tests_Async.cs
@@ -116,8 +116,8 @@ public partial class L1L2Tests
 
 	[Theory]
 	[ClassData(typeof(SerializerTypesClassData))]
-	public async Task DistributedCacheCircuitBreakerActuallyWorksAsync(SerializerType serializerType)
-	{
+        public async Task DistributedCacheCircuitBreakerActuallyWorksAsync(SerializerType serializerType)
+        {
 		var keyFoo = CreateRandomCacheKey("foo");
 
 		var circuitBreakerDuration = TimeSpan.FromSeconds(2);
@@ -141,8 +141,76 @@ public partial class L1L2Tests
 		memoryCache.Remove(TestsUtils.MaybePreProcessCacheKey(keyFoo, TestingCacheKeyPrefix));
 		var res = await fusionCache.GetOrDefaultAsync<int>(keyFoo, -1);
 
-		Assert.Equal(1, res);
-	}
+                Assert.Equal(1, res);
+        }
+
+        [Fact]
+        public async Task DistributedCacheAdvancedCircuitBreakerWorksAsync()
+        {
+                var keyFoo = CreateRandomCacheKey("foo");
+
+                var circuitBreakerDuration = TimeSpan.FromMilliseconds(500);
+                var distributedCache = new CountingDistributedCache(new MemoryDistributedCache(new MemoryDistributedCacheOptions()));
+                var chaosDistributedCache = new ChaosDistributedCache(distributedCache);
+
+                using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+                var options = CreateFusionCacheOptions();
+                options.EnableAutoRecovery = false;
+                options.DistributedCacheCircuitBreakerDuration = circuitBreakerDuration;
+                options.DistributedCacheCircuitBreakerFailureThreshold = 0.5;
+                options.DistributedCacheCircuitBreakerSamplingDuration = TimeSpan.FromSeconds(1);
+                options.DistributedCacheCircuitBreakerMinimumThroughput = 2;
+                using var fusionCache = new FusionCache(options, memoryCache);
+                fusionCache.DefaultEntryOptions.AllowBackgroundDistributedCacheOperations = false;
+                fusionCache.SetupDistributedCache(chaosDistributedCache, TestsUtils.GetSerializer(SerializerType.SystemTextJson));
+
+                await fusionCache.SetAsync<int>(keyFoo, 1, o => o.SetDurationSec(60).SetFailSafe(true));
+                chaosDistributedCache.SetAlwaysThrow();
+                await fusionCache.SetAsync<int>(keyFoo, 2, o => o.SetDurationSec(60).SetFailSafe(true));
+                chaosDistributedCache.SetNeverThrow();
+                await Task.Delay(circuitBreakerDuration.PlusALittleBit());
+                memoryCache.Remove(TestsUtils.MaybePreProcessCacheKey(keyFoo, TestingCacheKeyPrefix));
+                var res1 = await fusionCache.GetOrDefaultAsync<int>(keyFoo, -1);
+                var res2 = await fusionCache.GetOrDefaultAsync<int>(keyFoo, -1);
+
+                Assert.Equal(1, res1);
+                Assert.Equal(1, res2);
+                Assert.Equal(1, distributedCache.GetCalls);
+        }
+
+        [Fact]
+        public async Task DistributedCacheAdvancedCircuitBreakerAllowsSingleTestCallAsync()
+        {
+                var keyFoo = CreateRandomCacheKey("foo");
+
+                var circuitBreakerDuration = TimeSpan.FromMilliseconds(500);
+                var distributedCache = new CountingDistributedCache(new MemoryDistributedCache(new MemoryDistributedCacheOptions()));
+                var chaosDistributedCache = new ChaosDistributedCache(distributedCache);
+
+                using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+                var options = CreateFusionCacheOptions();
+                options.EnableAutoRecovery = false;
+                options.DistributedCacheCircuitBreakerDuration = circuitBreakerDuration;
+                options.DistributedCacheCircuitBreakerFailureThreshold = 0.5;
+                options.DistributedCacheCircuitBreakerSamplingDuration = TimeSpan.FromSeconds(1);
+                options.DistributedCacheCircuitBreakerMinimumThroughput = 2;
+                using var fusionCache = new FusionCache(options, memoryCache);
+                fusionCache.DefaultEntryOptions.AllowBackgroundDistributedCacheOperations = false;
+                fusionCache.SetupDistributedCache(chaosDistributedCache, TestsUtils.GetSerializer(SerializerType.SystemTextJson));
+
+                await fusionCache.SetAsync<int>(keyFoo, 1, o => o.SetDurationSec(60).SetFailSafe(true));
+                chaosDistributedCache.SetAlwaysThrow();
+                await fusionCache.SetAsync<int>(keyFoo, 2, o => o.SetDurationSec(60).SetFailSafe(true));
+                chaosDistributedCache.SetNeverThrow();
+                await Task.Delay(circuitBreakerDuration.PlusALittleBit());
+                memoryCache.Remove(TestsUtils.MaybePreProcessCacheKey(keyFoo, TestingCacheKeyPrefix));
+
+                var t1 = fusionCache.GetOrDefaultAsync<int>(keyFoo, -1);
+                var t2 = fusionCache.GetOrDefaultAsync<int>(keyFoo, -1);
+                await Task.WhenAll(t1, t2);
+
+                Assert.Equal(1, distributedCache.GetCalls);
+        }
 
 	private async Task _DistributedCacheWireVersionModifierWorksAsync(SerializerType serializerType, CacheKeyModifierMode modifierMode)
 	{

--- a/tests/ZiggyCreatures.FusionCache.Tests/Stuff/CountingDistributedCache.cs
+++ b/tests/ZiggyCreatures.FusionCache.Tests/Stuff/CountingDistributedCache.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace FusionCacheTests.Stuff
+{
+    internal class CountingDistributedCache : IDistributedCache
+    {
+        private readonly IDistributedCache _inner;
+        public int GetCalls => _getCalls;
+        private int _getCalls;
+        public int SetCalls => _setCalls;
+        private int _setCalls;
+        public int RemoveCalls => _removeCalls;
+        private int _removeCalls;
+
+        public CountingDistributedCache(IDistributedCache inner)
+        {
+            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        }
+
+        public byte[]? Get(string key)
+        {
+            Interlocked.Increment(ref _getCalls);
+            return _inner.Get(key);
+        }
+
+        public async Task<byte[]?> GetAsync(string key, CancellationToken token = default)
+        {
+            Interlocked.Increment(ref _getCalls);
+            return await _inner.GetAsync(key, token).ConfigureAwait(false);
+        }
+
+        public void Refresh(string key)
+        {
+            _inner.Refresh(key);
+        }
+
+        public Task RefreshAsync(string key, CancellationToken token = default)
+        {
+            return _inner.RefreshAsync(key, token);
+        }
+
+        public void Remove(string key)
+        {
+            Interlocked.Increment(ref _removeCalls);
+            _inner.Remove(key);
+        }
+
+        public async Task RemoveAsync(string key, CancellationToken token = default)
+        {
+            Interlocked.Increment(ref _removeCalls);
+            await _inner.RemoveAsync(key, token).ConfigureAwait(false);
+        }
+
+        public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
+        {
+            Interlocked.Increment(ref _setCalls);
+            _inner.Set(key, value, options);
+        }
+
+        public async Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
+        {
+            Interlocked.Increment(ref _setCalls);
+            await _inner.SetAsync(key, value, options, token).ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend `SimpleCircuitBreaker` with advanced logic including half-open state
- expose advanced circuit breaker options for distributed cache and backplane
- hook circuit breaker success calls in distributed cache and backplane accessors
- add counting distributed cache for testing
- test advanced circuit breaker behaviour and single half-open call logic

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886a6fc05588333b885d0292fc3a7c9